### PR TITLE
Simplifies the loan structure

### DIFF
--- a/lib/loan_ranger/loan.ex
+++ b/lib/loan_ranger/loan.ex
@@ -6,81 +6,77 @@ defmodule LoanRanger.Loan do
   @enforce_keys [
     :loan_amount,
     :annual_interest_rate,
-    :payment_type,
     :payment_amount,
     :opening_date,
     :term,
-    :first_payment_date,
-    :payday
   ]
   defstruct [
     :loan_amount,
     :annual_interest_rate,
-    :payment_type,
     :payment_amount,
     :opening_date,
     :term,
-    :first_payment_date,
-    :payday
   ]
 
+  @default_opts [currency: :USD]
+
   @doc """
-  Create loan struct
+  Create loan struct.
+
+
+  You need to pass monetary values ​​as a positive integer that represents how much in the smallest currency
+  unit (for example, 100 cents to $ 1.00).
+  You can specify the currency with the argument opts. LoanRanger works with [Money library](https://github.com/elixirmoney/money).
+  The default currency is USD.
 
   ## Example
   ```
   params = %{
-    loan_amount: "85000",
+    loan_amount: 8_500_000,
     annual_interest_rate: "60.0",
-    payment_type: :monthly,
-    payment_amount: "7595",
+    payment_amount: 759_500,
     opening_date: "2018-12-28",
     term: 18,
-    first_payment_date: "2019-01-15",
-    payday: 15
    }
 
-  iex > LoanRanger.Loan.create(params)
+  opts = [currency: :USD]
+
+  iex > LoanRanger.Loan.create(params, opts)
   {:ok,
     %LoanRanger.Loan{
       loan_amount: %Money{amount: 8500000, currency: :USD},
       annual_interest_rate: #Decimal<60.0>,
-      payment_type: :monthly,
       payment_amount: %Money{amount: 759500, currency: :USD},
       opening_date: ~D[2018-12-28],
-      term: 18,
-      first_payment_date: ~D[2019-01-15],
-      payday: 15
+      term: 18
     }
   }
 
-    
+
   ```
   """
   @spec create(map) :: Loant.t()
   def create(%{
-        loan_amount: loan_amount,
-        annual_interest_rate: annual_interest_rate,
-        payment_type: payment_type,
-        payment_amount: payment_amount,
-        opening_date: opening_date,
-        term: term,
-        first_payment_date: first_payment_date,
-        payday: payday
-      })
-      when is_binary(loan_amount) and is_binary(annual_interest_rate) and is_atom(payment_type) and
-             is_binary(payment_amount) and is_binary(opening_date) and is_integer(term) and
-             is_binary(first_payment_date) and
-             is_integer(payday) do
+    loan_amount: loan_amount,
+    annual_interest_rate: annual_interest_rate,
+    payment_amount: payment_amount,
+    opening_date: opening_date,
+    term: term
+  }, opts \\ @default_opts)
+      when is_integer(loan_amount)
+           and is_binary(annual_interest_rate)
+           and is_integer(payment_amount)
+           and is_binary(opening_date)
+           and is_integer(term) do
+
+    currency = Keyword.get(opts, :currency)
+
     loan = %__MODULE__{
-      loan_amount: Money.parse!(loan_amount),
+      loan_amount: Money.new(loan_amount, currency),
       annual_interest_rate: Decimal.new(annual_interest_rate),
-      payment_type: payment_type,
-      payment_amount: Money.parse!(payment_amount),
+      payment_amount: Money.new(payment_amount, currency),
       opening_date: Date.from_iso8601!(opening_date),
-      term: term,
-      first_payment_date: Date.from_iso8601!(first_payment_date),
-      payday: payday
+      term: term
     }
 
     {:ok, loan}

--- a/test/loan_ranger/loan_test.exs
+++ b/test/loan_ranger/loan_test.exs
@@ -7,14 +7,11 @@ defmodule LoanTest do
 
   test "create/1 return a loan structure" do
     params = %{
-      loan_amount: "85000",
+      loan_amount: 8_500_000,
       annual_interest_rate: "60.0",
-      payment_type: :monthly,
-      payment_amount: "7595",
+      payment_amount: 759_500,
       opening_date: "2018-12-28",
-      term: 18,
-      first_payment_date: "2019-01-15",
-      payday: 15
+      term: 18
     }
 
     assert Loan.create(params) ==
@@ -22,12 +19,9 @@ defmodule LoanTest do
               %Loan{
                 loan_amount: %Money{amount: 8_500_000, currency: :USD},
                 annual_interest_rate: Decimal.new("60.0"),
-                payment_type: :monthly,
                 payment_amount: %Money{amount: 759_500, currency: :USD},
                 opening_date: Date.from_iso8601!("2018-12-28"),
-                term: 18,
-                first_payment_date: Date.from_iso8601!("2019-01-15"),
-                payday: 15
+                term: 18
               }}
   end
 end


### PR DESCRIPTION
- Remove the keys: 
  - payment_type
  - first_payment_date
  - payday

- Now the monetary values ​​must be integers.
- Add the ability to specify the currency.
- Update the documentation of the function `create`.